### PR TITLE
Add batch membership and check-in status icons to AddressInfoDropdown…

### DIFF
--- a/packages/nextjs/components/scaffold-eth/RainbowKitCustomConnectButton/AddressInfoDropdown.tsx
+++ b/packages/nextjs/components/scaffold-eth/RainbowKitCustomConnectButton/AddressInfoDropdown.tsx
@@ -24,6 +24,7 @@ const allowedNetworks = getTargetNetworks();
 
 const batchRegistryAbi = batchRegistryJson.abi;
 const BATCH_REGISTRY_ADDRESS = "0x47FD1Ff08476d7c7196089D4f5BcabbED4f4ddbE";
+// const BATCH_REGISTRY_ADDRESS = "0x0000000000000000000000000000000000000000";
 
 type AddressInfoDropdownProps = {
   address: Address;
@@ -121,7 +122,7 @@ export const AddressInfoDropdown = ({
                   className="text-xl font-normal h-6 w-4 cursor-pointer ml-2 sm:ml-0"
                   aria-hidden="true"
                 />
-                <span className=" whitespace-nowrap">Copy address</span>
+                <span className="whitespace-nowrap">Copy address</span>
               </div>
             ) : (
               <CopyToClipboard
@@ -138,7 +139,7 @@ export const AddressInfoDropdown = ({
                     className="text-xl font-normal h-6 w-4 cursor-pointer ml-2 sm:ml-0"
                     aria-hidden="true"
                   />
-                  <span className=" whitespace-nowrap">Copy address</span>
+                  <span className="whitespace-nowrap">Copy address</span>
                 </div>
               </CopyToClipboard>
             )}


### PR DESCRIPTION
… (Issue #4)

## Description
Added batch membership and check-in status icons to the AddressInfoDropdown component as per Issue #4.  
Used Heroicons for consistent styling:
- Green UserIcon if the address is in the allowList, red ExclamationCircleIcon if not.
- Green CheckCircleIcon if the address has checked in, red ExclamationCircleIcon if not.

## Screenshots
- Success (in allowList and checked in):
![Screenshot 2025-03-24 at 20 28 17](https://github.com/user-attachments/assets/bfa625d6-ad6d-4be6-a9c0-432864b148a0)
- Error (simulated):
![Screenshot 2025-03-24 at 20 32 39](https://github.com/user-attachments/assets/42acf3be-2828-4843-83bb-5ac6c464bbfd)
- Not in allowList/Not checked in (simulated):
![Screenshot 2025-03-24 at 20 28 09](https://github.com/user-attachments/assets/f45de282-2f37-4a0f-8b7a-6ab2158cd1f8)
- Not in allowList/Checked in (simulated):
![Screenshot 2025-03-24 at 20 27 44](https://github.com/user-attachments/assets/66f08cef-0e25-4ab4-939c-f0b760ec2490)
- In allowList/Not checked in (simulated):
![Screenshot 2025-03-24 at 20 27 59](https://github.com/user-attachments/assets/27c1bd63-a402-44d5-8b27-0e1d674fc2bf)

## Additional Information

- [x] I have read the [contributing docs](/scaffold-eth/scaffold-eth-2/blob/main/CONTRIBUTING.md) (if this is your first contribution)
- [x] This is not a duplicate of any [existing pull request](https://github.com/scaffold-eth/scaffold-eth-2/pulls)

Your ENS/address:
0xd22BFCA3DAb60c1a11b2f1d7C8e2CBa063716A38