### PR TITLE
Builders list Added

### DIFF
--- a/packages/nextjs/app/api/builders/[address]/route.ts
+++ b/packages/nextjs/app/api/builders/[address]/route.ts
@@ -1,0 +1,18 @@
+import { NextResponse } from "next/server";
+import fs from "fs";
+import path from "path";
+
+export async function GET(request: Request, { params }: { params: { address: string } }) {
+  try {
+    const address = params.address;
+    const profilePath = path.join(process.cwd(), "app", "builders", address, "page.tsx");
+
+    // Check if the profile page exists
+    const exists = fs.existsSync(profilePath);
+
+    return NextResponse.json({ exists });
+  } catch (error) {
+    console.error("Error checking profile:", error);
+    return NextResponse.json({ exists: false });
+  }
+}

--- a/packages/nextjs/app/builders/page.tsx
+++ b/packages/nextjs/app/builders/page.tsx
@@ -51,7 +51,7 @@ export default function Page() {
   const { data: events } = useScaffoldEventHistory({
     contractName: "BatchRegistry",
     eventName: "CheckedIn",
-    fromBlock: 314188177n, // About 10k blocks before contract deployment (block 314198177)
+    fromBlock: 314186263n, // 10 blocks before contract deployment (block 314186273)
     chainId: 42161,
   });
 

--- a/packages/nextjs/app/builders/page.tsx
+++ b/packages/nextjs/app/builders/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useMemo, useRef } from "react";
+import { useMemo } from "react";
 import Image from "next/image";
 import Link from "next/link";
 import { Address } from "~~/components/scaffold-eth";
@@ -48,28 +48,26 @@ const BUILDER_PROFILES: Record<string, { name: string; avatarUrl: string }> = {
 };
 
 export default function Page() {
-  const elementRef = useRef(null);
-
   const { data: events } = useScaffoldEventHistory({
     contractName: "BatchRegistry",
     eventName: "CheckedIn",
-    fromBlock: 0n,
+    fromBlock: 314188177n, // About 10k blocks before contract deployment (block 314198177)
     chainId: 42161,
   });
 
   const builders = useMemo<Builder[]>(() => {
     if (!events) return [];
 
-    // Filter out duplicate addresses
-    const filteredAddresses: string[] = [];
+    // Filter out duplicate addresses to get unique ones
+    const uniqueAddresses: string[] = [];
     events.forEach(event => {
       const address = event.args.builder;
       if (!address) return;
-      if (!filteredAddresses.find(addr => address === addr)) filteredAddresses.push(address);
+      if (!uniqueAddresses.find(addr => address === addr)) uniqueAddresses.push(address);
     });
 
     // Transform addresses into builder objects
-    const buildersList = filteredAddresses.map(address => ({
+    const buildersList = uniqueAddresses.map(address => ({
       address,
       // Check if the builder has a personal page
       hasPersonalPage: !!Object.keys(BUILDER_PROFILES).find(bp => bp.toLowerCase() === address.toLowerCase()),
@@ -89,7 +87,7 @@ export default function Page() {
 
   return (
     <div className="min-h-screen bg-gradient-to-b from-base-200 to-base-300">
-      <div className="container mx-auto px-4 py-12" ref={elementRef}>
+      <div className="container mx-auto px-4 py-12">
         {/* Hero Section */}
         <div className="text-center mb-16">
           <h1 className="text-5xl font-extrabold mb-4 bg-gradient-to-r from-purple-600 via-pink-500 to-blue-500 text-transparent bg-clip-text">
@@ -106,24 +104,15 @@ export default function Page() {
                   {/* Avatar image */}
                   <div className="avatar">
                     <div className="w-10 h-10 rounded-full ring ring-primary ring-offset-base-100 ring-offset-1 overflow-hidden">
-                      {builder.avatarUrl &&
-                        (builder.avatarUrl.startsWith("/") ? (
-                          <Image
-                            src={builder.avatarUrl}
-                            alt={`${builder.name}'s avatar`}
-                            width={48}
-                            height={48}
-                            className="w-full h-full object-cover"
-                          />
-                        ) : (
-                          <Image
-                            src={builder.avatarUrl}
-                            alt={`${builder.name}'s avatar`}
-                            width={48}
-                            height={48}
-                            className="w-full h-full object-cover"
-                          />
-                        ))}
+                      {builder.avatarUrl && (
+                        <Image
+                          src={builder.avatarUrl}
+                          alt={`${builder.name}'s avatar`}
+                          width={48}
+                          height={48}
+                          className="w-full h-full object-cover"
+                        />
+                      )}
                     </div>
                   </div>
 

--- a/packages/nextjs/app/builders/page.tsx
+++ b/packages/nextjs/app/builders/page.tsx
@@ -1,0 +1,217 @@
+"use client";
+
+import { useEffect, useRef, useState } from "react";
+import Image from "next/image";
+import Link from "next/link";
+import { Address } from "~~/components/scaffold-eth";
+import { useScaffoldEventHistory } from "~~/hooks/scaffold-eth";
+
+type Builder = {
+  address: string;
+  hasPersonalPage: boolean;
+  profilePath?: string;
+  name?: string;
+  avatarUrl?: string;
+  // Map of builder addresses to their profile image paths
+  profileImageMap?: Record<string, string>;
+};
+
+const KNOWN_PROFILES = [
+  "0x78F348Dc5De2e9f066FAAa0bfD66d397a9260A43",
+  "0xA35D2C518710D3f953Ce4F69CDDEAaFc0c6b156c",
+  "0xC4Aad525854Cc8d21122Bee8CcC1d9c3cEcBb859",
+  "0xcC6eDeB501BbD8AD9E028BDe937B63Cdd64A1D91",
+  "0xd22BFCA3DAb60c1a11b2f1d7C8e2CBa063716A38",
+  "0xe1DfD545a57721FCC2b7433c5Eb657AB3B851Bf7",
+];
+
+// Map of builder addresses to their profile images
+const PROFILE_IMAGE_MAP: Record<string, string> = {
+  "0x78F348Dc5De2e9f066FAAa0bfD66d397a9260A43": "/0x7.jpg",
+  "0xA35D2C518710D3f953Ce4F69CDDEAaFc0c6b156c":
+    "https://static.vecteezy.com/system/resources/previews/002/469/825/non_2x/black-and-white-line-art-of-the-front-of-the-lion-head-it-is-sign-of-leo-zodiac-good-use-for-symbol-mascot-icon-avatar-tattoo-t-shirt-design-logo-or-any-design-free-vector.jpg",
+  "0xC4Aad525854Cc8d21122Bee8CcC1d9c3cEcBb859": "/krishna-profile.png",
+  "0xcC6eDeB501BbD8AD9E028BDe937B63Cdd64A1D91": "/agooniavatar.png",
+  "0xd22BFCA3DAb60c1a11b2f1d7C8e2CBa063716A38": "/builders/0xd22BFCA3DAb60c1a11b2f1d7C8e2CBa063716A38/avatar.jpg",
+  "0xe1DfD545a57721FCC2b7433c5Eb657AB3B851Bf7":
+    "https://avatars.githubusercontent.com/u/31843278?s=400&u=e11dfd17649cf868c737ff5fc526d88a55d5eb1d&v=4",
+  // For other builders, i have used the generated avatars
+};
+
+// Map of builder addresses to their real names
+const BUILDER_NAMES_MAP: Record<string, string> = {
+  "0x78F348Dc5De2e9f066FAAa0bfD66d397a9260A43": "Tejas Sandwar",
+  "0xA35D2C518710D3f953Ce4F69CDDEAaFc0c6b156c": "Joseph Aleonomoh",
+  "0xC4Aad525854Cc8d21122Bee8CcC1d9c3cEcBb859": "Krishna Singh",
+  "0xcC6eDeB501BbD8AD9E028BDe937B63Cdd64A1D91": "Agooni",
+  "0xd22BFCA3DAb60c1a11b2f1d7C8e2CBa063716A38": "Enrique",
+  "0xe1DfD545a57721FCC2b7433c5Eb657AB3B851Bf7": "Huilén Canullán",
+  // For other builders, i have referred them as "Builder"
+};
+
+export default function Page() {
+  const [builders, setBuilders] = useState([] as Builder[]);
+  const [isLoading, setIsLoading] = useState(true);
+  const [builderProfiles, setBuilderProfiles] = useState<string[]>([]);
+  const [profileImageMap, setProfileImageMap] = useState<Record<string, string>>({});
+  const [builderNamesMap, setBuilderNamesMap] = useState<Record<string, string>>({});
+  const elementRef = useRef(null);
+
+  const { data: events } = useScaffoldEventHistory({
+    contractName: "BatchRegistry",
+    eventName: "CheckedIn",
+    fromBlock: 0n,
+    chainId: 42161,
+  });
+
+  useEffect(() => {
+    const checkBuilderProfiles = async () => {
+      try {
+        setBuilderProfiles(KNOWN_PROFILES);
+        setProfileImageMap(PROFILE_IMAGE_MAP);
+        setBuilderNamesMap(BUILDER_NAMES_MAP);
+        console.log("Found builder profiles:", KNOWN_PROFILES);
+      } catch (error) {
+        console.error("Error checking builder profiles:", error);
+      }
+    };
+
+    checkBuilderProfiles();
+  }, []);
+
+  useEffect(() => {
+    if (elementRef.current) {
+      setIsLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    const fetchBuilders = async () => {
+      if (!events) return;
+
+      // Filter out duplicate addresses
+      const filteredAddresses: string[] = [];
+      events.forEach(event => {
+        const address = event.args.builder;
+        if (!address) return;
+        if (!filteredAddresses.find(addr => address === addr)) filteredAddresses.push(address);
+      });
+
+      const builders = await Promise.all(
+        filteredAddresses.map(async address => {
+          if (address)
+            return {
+              address,
+              // Check if the builder has a personal page
+              hasPersonalPage: !!builderProfiles.find(bp => bp.toLowerCase() === address.toLowerCase()),
+              // Store the profile path for navigation
+              profilePath: `/builders/${address}`,
+              // Used real name if available, otherwise used Builder
+              name: builderNamesMap[address] || "Builder",
+              // Use profile image if available, otherwise fallback to generated avatar
+              avatarUrl: profileImageMap[address] || `https://effigy.im/a/${address}.svg`,
+            };
+        }),
+      );
+      setBuilders(
+        builders
+          .filter(builder => !!builder)
+          // Sort by personal page availability
+          .sort((a, b) => +(b.hasPersonalPage === true) - +(a.hasPersonalPage === true)),
+      );
+    };
+
+    fetchBuilders().catch(console.error);
+  }, [events, builderProfiles, builderNamesMap, profileImageMap]);
+
+  return (
+    <div className="min-h-screen bg-gradient-to-b from-base-200 to-base-300">
+      <div className="container mx-auto px-4 py-12" ref={elementRef}>
+        {/* Hero Section */}
+        <div className="text-center mb-16">
+          <h1 className="text-5xl font-extrabold mb-4 bg-gradient-to-r from-purple-600 via-pink-500 to-blue-500 text-transparent bg-clip-text">
+            Batch 14 Builders
+          </h1>
+        </div>
+
+        {/* Builders Grid */}
+        {isLoading ? (
+          <div className="flex flex-col items-center justify-center py-12">
+            <div className="animate-spin rounded-full h-16 w-16 border-b-2 border-primary mb-4"></div>
+            <p className="text-xl font-medium">Loading builders...</p>
+          </div>
+        ) : (
+          <div className="grid grid-cols-1 md:grid-cols-3 lg:grid-cols-4 gap-4">
+            {builders.map((builder, id) => (
+              <div
+                key={id}
+                className="card bg-base-100 shadow hover:shadow-md transition-all duration-300 overflow-hidden border border-transparent hover:border-primary"
+              >
+                <div className="card-body p-3">
+                  <div className="flex items-center gap-3 mb-1">
+                    {/* Avatar image */}
+                    <div className="avatar">
+                      <div className="w-10 h-10 rounded-full ring ring-primary ring-offset-base-100 ring-offset-1 overflow-hidden">
+                        {builder.avatarUrl &&
+                          (builder.avatarUrl.startsWith("/") ? (
+                            <Image
+                              src={builder.avatarUrl}
+                              alt={`${builder.name}'s avatar`}
+                              width={48}
+                              height={48}
+                              className="w-full h-full object-cover"
+                            />
+                          ) : (
+                            <Image
+                              src={builder.avatarUrl}
+                              alt={`${builder.name}'s avatar`}
+                              width={48}
+                              height={48}
+                              className="w-full h-full object-cover"
+                            />
+                          ))}
+                      </div>
+                    </div>
+
+                    <div>
+                      <h3 className="font-bold text-sm">{builder.name}</h3>
+                      <div className="text-xs truncate">
+                        <Address address={builder.address} />
+                      </div>
+                    </div>
+                  </div>
+
+                  <div className="card-actions justify-end mt-1">
+                    {builder.hasPersonalPage ? (
+                      <Link href={builder.profilePath || `#`} className="btn btn-xs btn-primary">
+                        View
+                      </Link>
+                    ) : (
+                      <button className="btn btn-xs btn-outline" disabled>
+                        No Profile
+                      </button>
+                    )}
+                  </div>
+                </div>
+              </div>
+            ))}
+          </div>
+        )}
+
+        {/* Empty State */}
+        {!isLoading && builders.length === 0 && (
+          <div className="text-center py-16">
+            <h1 className="text-5xl font-extrabold mb-4 animate-text bg-gradient-to-r from-purple-600 via-pink-500 to-blue-500 bg-clip-text text-transparent">
+              Meet the Builders of Batch 14
+            </h1>
+
+            <p className="mt-6 text-xl text-gray-600 max-w-2xl mx-auto">
+              The brightest minds building the future of web3. Explore their profiles and see what they&apos;re
+              creating!
+            </p>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/packages/nextjs/app/builders/page.tsx
+++ b/packages/nextjs/app/builders/page.tsx
@@ -62,11 +62,12 @@ export default function Page() {
 
       const existingPages = new Set<string>();
 
-      // Check each address for a profile page
+      // Check each address for a profile page using the API
       for (const address of uniqueAddresses) {
         try {
-          const response = await fetch(`/builders/${address}`);
-          if (response.ok) {
+          const response = await fetch(`/api/builders/${address}`);
+          const data = await response.json();
+          if (data.exists) {
             existingPages.add(address);
           }
         } catch (error) {

--- a/packages/nextjs/app/builders/page.tsx
+++ b/packages/nextjs/app/builders/page.tsx
@@ -1,7 +1,6 @@
 "use client";
 
-import { useMemo } from "react";
-import Image from "next/image";
+import { useEffect, useMemo, useState } from "react";
 import Link from "next/link";
 import { Address } from "~~/components/scaffold-eth";
 import { useScaffoldEventHistory } from "~~/hooks/scaffold-eth";
@@ -10,42 +9,34 @@ type Builder = {
   address: string;
   hasPersonalPage: boolean;
   profilePath?: string;
-  name?: string;
-  avatarUrl?: string;
 };
 
-// Consolidated builder profiles in a single map
-const BUILDER_PROFILES: Record<string, { name: string; avatarUrl: string }> = {
-  "0x78F348Dc5De2e9f066FAAa0bfD66d397a9260A43": {
-    name: "Tejas Sandwar",
-    avatarUrl: "/0x7.jpg",
-  },
-  "0xA35D2C518710D3f953Ce4F69CDDEAaFc0c6b156c": {
-    name: "Joseph Aleonomoh",
-    avatarUrl:
-      "https://static.vecteezy.com/system/resources/previews/002/469/825/non_2x/black-and-white-line-art-of-the-front-of-the-lion-head-it-is-sign-of-leo-zodiac-good-use-for-symbol-mascot-icon-avatar-tattoo-t-shirt-design-logo-or-any-design-free-vector.jpg",
-  },
-  "0xC4Aad525854Cc8d21122Bee8CcC1d9c3cEcBb859": {
-    name: "Krishna Singh",
-    avatarUrl: "/krishna-profile.png",
-  },
-  "0xcC6eDeB501BbD8AD9E028BDe937B63Cdd64A1D91": {
-    name: "Agooni",
-    avatarUrl: "/agooniavatar.png",
-  },
-  "0xd22BFCA3DAb60c1a11b2f1d7C8e2CBa063716A38": {
-    name: "Enrique",
-    avatarUrl: "/builders/0xd22BFCA3DAb60c1a11b2f1d7C8e2CBa063716A38/avatar.jpg",
-  },
-  "0xe1DfD545a57721FCC2b7433c5Eb657AB3B851Bf7": {
-    name: "Huilén Canullán",
-    avatarUrl: "https://avatars.githubusercontent.com/u/31843278?s=400&u=e11dfd17649cf868c737ff5fc526d88a55d5eb1d&v=4",
-  },
-  "0xA6e8bf8E89Bd2c2BD37e308F275C4f52284a911F": {
-    name: "Osiyomeoh Aleonomoh",
-    avatarUrl: "https://avatars.githubusercontent.com/u/92280484?v=4",
-  },
-};
+// Separate component for builder card
+function BuilderCard({ builder }: { builder: Builder }) {
+  return (
+    <div className="card bg-base-100 shadow overflow-hidden border border-base-300">
+      <div className="card-body p-3">
+        <div className="flex items-center gap-3 mb-1">
+          <div>
+            <div className="text-xs truncate">
+              <Address address={builder.address} />
+            </div>
+          </div>
+        </div>
+
+        <div className="card-actions justify-end mt-1">
+          {builder.hasPersonalPage ? (
+            <Link href={builder.profilePath || `#`} className="btn btn-xs btn-primary">
+              View
+            </Link>
+          ) : (
+            <span className="text-xs text-base-content/60">No Profile</span>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}
 
 export default function Page() {
   const { data: events } = useScaffoldEventHistory({
@@ -54,6 +45,40 @@ export default function Page() {
     fromBlock: 314186263n, // 10 blocks before contract deployment (block 314186273)
     chainId: 42161,
   });
+
+  const [profilePages, setProfilePages] = useState<Set<string>>(new Set());
+
+  // Check which profile pages exist
+  useEffect(() => {
+    const checkProfilePages = async () => {
+      if (!events) return;
+
+      const uniqueAddresses: string[] = [];
+      events.forEach(event => {
+        const address = event.args.builder;
+        if (!address) return;
+        if (!uniqueAddresses.find(addr => address === addr)) uniqueAddresses.push(address);
+      });
+
+      const existingPages = new Set<string>();
+
+      // Check each address for a profile page
+      for (const address of uniqueAddresses) {
+        try {
+          const response = await fetch(`/builders/${address}`);
+          if (response.ok) {
+            existingPages.add(address);
+          }
+        } catch (error) {
+          console.error(`Error checking profile for ${address}:`, error);
+        }
+      }
+
+      setProfilePages(existingPages);
+    };
+
+    checkProfilePages();
+  }, [events]);
 
   const builders = useMemo<Builder[]>(() => {
     if (!events) return [];
@@ -69,21 +94,15 @@ export default function Page() {
     // Transform addresses into builder objects
     const buildersList = uniqueAddresses.map(address => ({
       address,
-      // Check if the builder has a personal page
-      hasPersonalPage: !!Object.keys(BUILDER_PROFILES).find(bp => bp.toLowerCase() === address.toLowerCase()),
+      // Check if the builder has a personal page by checking if their profile exists
+      hasPersonalPage: profilePages.has(address),
       // Store the profile path for navigation
       profilePath: `/builders/${address}`,
-      // Used real name if available, otherwise used Builder
-      name: BUILDER_PROFILES[address]?.name || "Builder",
-      // Use profile image if available, otherwise fallback to generated avatar
-      avatarUrl: BUILDER_PROFILES[address]?.avatarUrl || `https://effigy.im/a/${address}.svg`,
     }));
 
-    // Filter out any undefined entries and sort by personal page availability
-    return buildersList
-      .filter(builder => !!builder)
-      .sort((a, b) => +(b.hasPersonalPage === true) - +(a.hasPersonalPage === true));
-  }, [events]);
+    // Filter out any undefined entries
+    return buildersList.filter(builder => !!builder);
+  }, [events, profilePages]);
 
   return (
     <div className="min-h-screen bg-gradient-to-b from-base-200 to-base-300">
@@ -98,45 +117,7 @@ export default function Page() {
         {/* Builders Grid */}
         <div className="grid grid-cols-1 md:grid-cols-3 lg:grid-cols-4 gap-4">
           {builders.map((builder, id) => (
-            <div key={id} className="card bg-base-100 shadow overflow-hidden border border-base-300">
-              <div className="card-body p-3">
-                <div className="flex items-center gap-3 mb-1">
-                  {/* Avatar image */}
-                  <div className="avatar">
-                    <div className="w-10 h-10 rounded-full ring ring-primary ring-offset-base-100 ring-offset-1 overflow-hidden">
-                      {builder.avatarUrl && (
-                        <Image
-                          src={builder.avatarUrl}
-                          alt={`${builder.name}'s avatar`}
-                          width={48}
-                          height={48}
-                          className="w-full h-full object-cover"
-                        />
-                      )}
-                    </div>
-                  </div>
-
-                  <div>
-                    <h3 className="font-bold text-sm">{builder.name}</h3>
-                    <div className="text-xs truncate">
-                      <Address address={builder.address} />
-                    </div>
-                  </div>
-                </div>
-
-                <div className="card-actions justify-end mt-1">
-                  {builder.hasPersonalPage ? (
-                    <Link href={builder.profilePath || `#`} className="btn btn-xs btn-primary">
-                      View
-                    </Link>
-                  ) : (
-                    <button className="btn btn-xs btn-outline" disabled>
-                      No Profile
-                    </button>
-                  )}
-                </div>
-              </div>
-            </div>
+            <BuilderCard key={id} builder={builder} />
           ))}
         </div>
       </div>

--- a/packages/nextjs/components/Header.tsx
+++ b/packages/nextjs/components/Header.tsx
@@ -21,6 +21,10 @@ export const menuLinks: HeaderMenuLink[] = [
     href: "/",
   },
   {
+    label: "Builders",
+    href: "/builders",
+  },
+  {
     label: "Debug Contracts",
     href: "/debug",
     icon: <BugAntIcon className="h-4 w-4" />,


### PR DESCRIPTION
## Description

This PR adds a new Builders page that displays all members of Batch 14 in a beautiful grid layout. The page includes:
- A responsive grid of builder cards
- Profile images (both custom and generated avatars)
- Real names and wallet addresses
- Links to personal builder pages
- Loading states and empty states
- A new navigation link in the header

## Features
- **Builder Cards**: Each card shows:
  - Builder's avatar (custom image if available else  generated)
  - Real name (if available)
  - Wallet address
  - View profile button (for builders with personal pages)

## Additional Information
Attached ScreenShot
<img width="1470" alt="Screenshot 2025-03-28 at 4 00 52 AM" src="https://github.com/user-attachments/assets/3a8aa405-1b95-4046-a5be-a94db91849f6" />


- [x] I have read the [contributing docs](/scaffold-eth/scaffold-eth-2/blob/main/CONTRIBUTING.md) (if this is your first contribution)
- [x] This is not a duplicate of any [existing pull request](https://github.com/scaffold-eth/scaffold-eth-2/pulls)

## Related Issues

_Closes #3_

_Note: If your changes are small and straightforward, you may skip the creation of an issue beforehand and remove this section. However, for medium-to-large changes, it is recommended to have an open issue for discussion and approval prior to submitting a pull request._

Your ENS/address: 0xC4Aad525854Cc8d21122Bee8CcC1d9c3cEcBb859
